### PR TITLE
docker: add extra hosts

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -13,3 +13,6 @@ services:
       timeout: {{ healthcheck_timeout }} 
       retries: {{ healthcheck_retries }}  
     env_file: "sonda.env"
+    # Sonda needs hostname to query the nim-waku-node container REST API port
+    extra_hosts:
+      - '{{ inventory_hostname }}:{{ ansible_local.wireguard.address }}'


### PR DESCRIPTION
This resolves issue of not being able to resolve hostname of host where sonda container is deployed from within the sonda container.